### PR TITLE
Add multiplexing capability in combination with the tca9548a

### DIFF
--- a/api/platform/vl53l1_platform.h
+++ b/api/platform/vl53l1_platform.h
@@ -76,7 +76,7 @@ extern "C"
 #endif
 
 
-void VL53L1_set_i2c(void *read_func, void *write_func);
+void VL53L1_set_i2c(void *multi_func, void *read_func, void *write_func);
 
 VL53L1_Error VL53L1_CommsInitialise(
 	VL53L1_DEV pdev,

--- a/api/platform/vl53l1_platform_user_data.h
+++ b/api/platform/vl53l1_platform_user_data.h
@@ -84,6 +84,8 @@ typedef struct {
 	uint16_t  comms_speed_khz;
 	uint32_t  new_data_ready_poll_duration_ms;
 	I2C_HandleTypeDef *I2cHandle;
+	uint8_t   TCA9548A_Device;           /*!< Device number on TCA9548A I2C Multiplexer or 255 if TCA9548A not being used */
+    uint8_t   TCA9548A_Address;          /*!< Address of TCA9548A I2C Multiplexer or 255 if TCA9548A not being used */
 
 } VL53L1_Dev_t;
 

--- a/examples/distance_multiplexer.py
+++ b/examples/distance_multiplexer.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import os
+import time
+import sys
+import signal
+
+import VL53L1X
+
+
+print("""distance.py
+
+Display the distance read from the sensor.
+
+Press Ctrl+C to exit.
+
+""")
+
+
+"""
+Open and start the VL53L1X ranging sensor for each channel of the TCA9548A
+"""
+tof1 = VL53L1X.VL53L1X(i2c_bus=1, i2c_address=0x29, tca9548a_num=2, tca9548a_addr=0x70)
+tof2 = VL53L1X.VL53L1X(i2c_bus=1, i2c_address=0x29, tca9548a_num=4, tca9548a_addr=0x70)
+tof1.open() # Initialise the i2c bus and configure the sensor
+tof1.start_ranging(3) # Start ranging, 1 = Short Range, 2 = Medium Range, 3 = Long Range
+tof2.open() # Initialise the i2c bus and configure the sensor
+tof2.start_ranging(3) # Start ranging, 1 = Short Range, 2 = Medium Range, 3 = Long Range
+
+
+running = True
+
+def exit_handler(signal, frame):
+    global running
+    running = False
+    tof1.stop_ranging() # Stop ranging
+    tof2.stop_ranging()  # Stop ranging
+    print()
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, exit_handler)
+
+while running:
+    distance_in_mm = tof1.get_distance() # Grab the range in mm
+    print("Sensor 1 distance: {}mm".format(distance_in_mm))
+    distance_in_mm = tof2.get_distance() # Grab the range in mm
+    print("Sensor 2 distance: {}mm".format(distance_in_mm))
+    time.sleep(0.1)
+

--- a/python_lib/vl53l1x_python.c
+++ b/python_lib/vl53l1x_python.c
@@ -45,7 +45,7 @@ static VL53L1_RangingMeasurementData_t *pRangingMeasurementData = &RangingMeasur
  *              being used. If not being used, set to 0.
  * @retval  The Dev Object to pass to other library functions.
  *****************************************************************************/
-VL53L1_DEV *initialise(uint8_t i2c_address)
+VL53L1_DEV *initialise(uint8_t i2c_address, uint8_t TCA9548A_Device, uint8_t TCA9548A_Address)
 {
     VL53L1_Error Status = VL53L1_ERROR_NONE;
     uint32_t refSpadCount;
@@ -57,10 +57,22 @@ VL53L1_DEV *initialise(uint8_t i2c_address)
     VL53L1_DeviceInfo_t                DeviceInfo;
     int32_t status_int;
 
+    if (TCA9548A_Device < 8)
+    {
+        printf ("VL53L1X Start Ranging Address 0x%02X TCA9548A Device %d TCA9548A Address 0x%02X\n\n",
+                    i2c_address, TCA9548A_Device, TCA9548A_Address);
+    }
+    else
+    {
+        printf ("VL53L1X Start Ranging Address 0x%02X\n\n", i2c_address);
+    }
+
     VL53L1_Dev_t *dev = (VL53L1_Dev_t *)malloc(sizeof(VL53L1_Dev_t));
     memset(dev, 0, sizeof(VL53L1_Dev_t));
 
     dev->I2cDevAddr = i2c_address;
+    dev->TCA9548A_Device = TCA9548A_Device;
+    dev->TCA9548A_Address = TCA9548A_Address;
     Status = VL53L1_software_reset(dev);
     Status = VL53L1_WaitDeviceBooted(dev);
     Status = VL53L1_DataInit(dev);


### PR DESCRIPTION
The library can now use any multiplexer that works in the same way as
the tca9548a device. An example on how to use the new functionality was
added under examples/distance_multiplexer.py. The code was tested on one
tca9548a device with three vl53l1x devices connected.
Fixes #13 