### PR TITLE
fixed a resource leak

### DIFF
--- a/python/VL53L1X.py
+++ b/python/VL53L1X.py
@@ -90,13 +90,14 @@ class VL53L1X:
         self._tca9548a_addr = tca9548a_addr
 
         self._i2c = SMBus()
-        try:
-            if tca9548a_num == 255:
+        if tca9548a_num == 255:
+            try:
                 self._i2c.open(bus=self._i2c_bus)
                 self._i2c.read_byte_data(self.i2c_address, 0x00)
+            except IOError:
+                raise RuntimeError("VL53L1X not found on adddress: {:02x}".format(self.i2c_address))
+            finally:
                 self._i2c.close()
-        except IOError:
-            raise RuntimeError("VL53L1X not found on adddress: {:02x}".format(self.i2c_address))
 
         self._dev = None
         # Register Address

--- a/python/VL53L1X.py
+++ b/python/VL53L1X.py
@@ -89,10 +89,12 @@ class VL53L1X:
         self._tca9548a_num = tca9548a_num
         self._tca9548a_addr = tca9548a_addr
 
-        self._i2c = SMBus(i2c_bus)
+        self._i2c = SMBus()
         try:
             if tca9548a_num == 255:
+                self._i2c.open(bus=self._i2c_bus)
                 self._i2c.read_byte_data(self.i2c_address, 0x00)
+                self._i2c.close()
         except IOError:
             raise RuntimeError("VL53L1X not found on adddress: {:02x}".format(self.i2c_address))
 


### PR DESCRIPTION
 I suggest a small fix. I've found a file descriptor leak which stays a device opened. I believe this is not critical usually and I know a work around, but in some case this gets reached 'Too many open files:'. 

 Given bus-number 1 for example as current situation, /dev/i2c-1 is opened in VL53L1X constructor(__init__()) , and same one is opened in VL53L1X.open() again. First one's reference is lost and unclosable.

 According to package smbus2, smbus2.SMBus() with bus-number opens /dev/i2c-X in itself or not open it without bus-number. Considering to let the pair of VL53L1X.open() and VL53L1X.close() work effectively, at the end of constructor /dev/i2c-X should be closed once.


 
