### PR TITLE
Fix I2C interface bug

### DIFF
--- a/api/platform/vl53l1_platform.c
+++ b/api/platform/vl53l1_platform.c
@@ -115,14 +115,14 @@
 // }
 
 // calls the i2c write to multiplexer function
-static int (*i2c_multi_func)(uint8_t address, uint8_t reg) = NULL;
+static int (*i2c_multi_func)(uint8_t address, uint16_t reg) = NULL;
 
 // calls read_i2c_block_data(address, reg, length)
-static int (*i2c_read_func)(uint8_t address, uint8_t reg,
+static int (*i2c_read_func)(uint8_t address, uint16_t reg,
 					uint8_t *list, uint8_t length) = NULL;
 
 // calls write_i2c_block_data(address, reg, list)
-static int (*i2c_write_func)(uint8_t address, uint8_t reg,
+static int (*i2c_write_func)(uint8_t address, uint16_t reg,
 					uint8_t *list, uint8_t length) = NULL;
 
 static pthread_mutex_t i2c_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -134,7 +134,7 @@ void VL53L1_set_i2c(void *multi_func, void *read_func, void *write_func)
 	i2c_write_func = write_func;
 }
 
-static int i2c_write(VL53L1_DEV Dev, uint8_t cmd,
+static int i2c_write(VL53L1_DEV Dev, uint16_t cmd,
                     uint8_t *data, uint8_t len)
 {
     int result = VL53L1_ERROR_NONE;
@@ -178,7 +178,7 @@ static int i2c_write(VL53L1_DEV Dev, uint8_t cmd,
     return result;
 }
 
-static int i2c_read(VL53L1_DEV Dev, uint8_t cmd,
+static int i2c_read(VL53L1_DEV Dev, uint16_t cmd,
                     uint8_t * data, uint8_t len)
 {
     int result = VL53L1_ERROR_NONE;

--- a/python/VL53L1X.py
+++ b/python/VL53L1X.py
@@ -21,7 +21,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32
+from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32, c_uint16
 from smbus2 import SMBus, i2c_msg
 import os
 import site
@@ -48,9 +48,9 @@ class VL53L1xUserRoi:
 
 
 # Read/write function pointer types.
-_I2C_MULTI_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte)
-_I2C_READ_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
-_I2C_WRITE_FUNC = CFUNCTYPE(c_int, c_ubyte, c_ubyte, POINTER(c_ubyte), c_ubyte)
+_I2C_MULTI_FUNC = CFUNCTYPE(c_int, c_ubyte, c_uint16)
+_I2C_READ_FUNC = CFUNCTYPE(c_int, c_ubyte, c_uint16, POINTER(c_ubyte), c_ubyte)
+_I2C_WRITE_FUNC = CFUNCTYPE(c_int, c_ubyte, c_uint16, POINTER(c_ubyte), c_ubyte)
 
 # Load VL53L1X shared lib
 _POSSIBLE_LIBRARY_LOCATIONS = [os.path.dirname(os.path.realpath(__file__))]

--- a/python_lib/vl53l1x_python.c
+++ b/python_lib/vl53l1x_python.c
@@ -56,6 +56,8 @@ VL53L1_DEV *initialise(uint8_t i2c_address, uint8_t TCA9548A_Device, uint8_t TCA
     VL53L1_Version_t                  *pVersion   = &Version;
     VL53L1_DeviceInfo_t                DeviceInfo;
     int32_t status_int;
+    uint8_t ModelId, ModuleType, MaskRev;
+
 
 #ifdef DEBUG
     if (TCA9548A_Device < 8)
@@ -82,12 +84,35 @@ VL53L1_DEV *initialise(uint8_t i2c_address, uint8_t TCA9548A_Device, uint8_t TCA
         Status = VL53L1_WaitDeviceBooted(dev);
     }
 
+    Status = VL53L1_RdByte(dev, 0x010F, &ModelId);
+    Status = VL53L1_RdByte(dev, 0x0110, &ModuleType);
+    Status = VL53L1_RdByte(dev, 0x0111, &MaskRev);
+
+# ifdef DEBUG
+    printf("VL53L1X I2C-Validity:\n");
+    printf("Model ID (should be 0xEA): 0x%X\n", ModelId);
+    printf("Module Type (should be 0xCC): 0x%X\n", ModuleType);
+    printf("Mask Revision (should be 0x10): 0x%X\n\n", MaskRev);
+#endif
+
+    // Check valid I2C interface as shown in VL53L1X data sheet page 22
+    if ((ModelId != 0xEA) || (ModuleType != 0xCC) || (MaskRev != 0x10))
+    {
+      printf("Warning: I2C interface invalid! Data might be corrupted!");
+    }
+
     Status = VL53L1_DataInit(dev);
     Status = VL53L1_StaticInit(dev);
     //if(Status == VL53L1_ERROR_NONE){
 #ifdef DEBUG
         Status = VL53L1_GetDeviceInfo(dev, &DeviceInfo);
         if(Status == VL53L1_ERROR_NONE){
+
+            printf("VL53L1X I2C-Validity:\n");
+            printf("Model ID (should be 0xEA): 0x%X\n");
+            printf("Module Type (should be 0xCC): 0x%X\n")
+            printf("Mask Revision (should be 0x10): 0x%X\n\n")
+
             printf("VL53L0X_GetDeviceInfo:\n");
             printf("Device Name : %s\n", DeviceInfo.Name);
             printf("Device Type : %s\n", DeviceInfo.Type);


### PR DESCRIPTION
I noticed some data inconsistencies while reading data from the vl53l1x using your python lib (as also mentioned in #35). ST provides some registry entries to check the i2c interface validity (see the vl53l1x data sheet https://www.st.com/resource/en/datasheet/vl53l1x.pdf on page 22). All are set to `0xff` when read in current master which is not correct.
This bugs derive from my point of view from wrong data types in the i2c_read and i2c_write functions. This
pull request fixes the issue as well as corrupted data in long data fields as i.g mentioned in #35. I also added some debug output for reading the mentioned registry entries and a warning if the values are not correct.