### PR TITLE
Fix segmentation fault by adding ctypes function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ https://shop.pimoroni.com/products/vl53l1x-breakout
 
 # Installing
 
-```
-sudo pip install smbus2
-sudo pip install vl53l1x
+It is recommended to build and install this package locally inside a virtual environment, as the PyPI version is outdated.
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install smbus2
+pip install .
 ```
 
 # Usage

--- a/python/VL53L1X.py
+++ b/python/VL53L1X.py
@@ -21,7 +21,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32, c_uint16
+from ctypes import CDLL, CFUNCTYPE, POINTER, c_int, c_uint, pointer, c_ubyte, c_uint8, c_uint32, c_uint16, c_void_p
 from smbus2 import SMBus, i2c_msg
 import os
 import site
@@ -78,6 +78,35 @@ for lib_location in _POSSIBLE_LIBRARY_LOCATIONS:
             pass
 else:
     raise OSError('Could not find vl53l1x_python.so')
+
+# Configure ctypes return types for C functions
+# This is critical to prevent segmentation faults!
+_TOF_LIBRARY.initialise.argtypes = [c_ubyte, c_ubyte, c_ubyte, c_ubyte]
+_TOF_LIBRARY.initialise.restype = c_void_p
+
+_TOF_LIBRARY.startRanging.argtypes = [c_void_p, c_int]
+_TOF_LIBRARY.startRanging.restype = c_int
+
+_TOF_LIBRARY.stopRanging.argtypes = [c_void_p]
+_TOF_LIBRARY.stopRanging.restype = None
+
+_TOF_LIBRARY.getDistance.argtypes = [c_void_p]
+_TOF_LIBRARY.getDistance.restype = c_int
+
+_TOF_LIBRARY.setDistanceMode.argtypes = [c_void_p, c_int]
+_TOF_LIBRARY.setDistanceMode.restype = c_int
+
+_TOF_LIBRARY.setUserRoi.argtypes = [c_void_p, c_int, c_int, c_int, c_int]
+_TOF_LIBRARY.setUserRoi.restype = c_int
+
+_TOF_LIBRARY.setMeasurementTimingBudgetMicroSeconds.argtypes = [c_void_p, c_int]
+_TOF_LIBRARY.setMeasurementTimingBudgetMicroSeconds.restype = c_int
+
+_TOF_LIBRARY.setInterMeasurementPeriodMilliSeconds.argtypes = [c_void_p, c_int]
+_TOF_LIBRARY.setInterMeasurementPeriodMilliSeconds.restype = c_int
+
+_TOF_LIBRARY.setDeviceAddress.argtypes = [c_void_p, c_int]
+_TOF_LIBRARY.setDeviceAddress.restype = c_int
 
 
 class VL53L1X:


### PR DESCRIPTION
The library was crashing with 'Segmentation fault (core dumped)' when calling start_ranging() and other methods on Python 3.7+ and 64-bit systems.

Root cause: ctypes was treating the pointer returned by initialise() as a 32-bit int instead of a 64-bit pointer, causing pointer truncation on 64-bit architectures.

Solution: Added explicit argtypes and restype declarations for all C function calls to preserve full pointer addresses.

Fixes segmentation faults reported in multiple issues on:
- Python 3.7+
- Raspberry Pi 4B, 5
- Jetson Nano, Orin
- Ubuntu 64-bit systems

Tested on: Jetson Orin with Python 3.10